### PR TITLE
security: escape user-controlled deviceName in OData filter

### DIFF
--- a/Collect-CustomInventory/Store-DataInLogWorkspace.ps1
+++ b/Collect-CustomInventory/Store-DataInLogWorkspace.ps1
@@ -38,7 +38,13 @@ function Get-DeviceNameValidated {
         [Parameter(Mandatory = $true)][string]$deviceName,
         [Parameter(Mandatory = $true)][string]$aadDeviceId
     )
-    $currentDeviceId = (Get-MgDevice -Filter "displayName eq '$deviceName'").DeviceId
+    # The device name comes from an HTTP request body and is therefore untrusted user
+    # input. Interpolating it directly into an OData $filter expression allows an
+    # attacker to break out of the string literal and modify the filter. Escape any
+    # single quotes per the OData spec (a literal quote is encoded as two quotes)
+    # before embedding the value.
+    $escapedDeviceName = $deviceName -replace "'", "''"
+    $currentDeviceId = (Get-MgDevice -Filter "displayName eq '$escapedDeviceName'").DeviceId
     if ($currentDeviceId -ne $aadDeviceId) {
         throw "The device name provided is not the same as the current device name"
     }


### PR DESCRIPTION
## Summary

- **Collect-CustomInventory/Store-DataInLogWorkspace.ps1:41** - The Azure Function validates an incoming inventory request by looking up the device in Azure AD via `Get-MgDevice -Filter "displayName eq '$deviceName'"`. `$deviceName` comes from the HTTP request body (`data.hostname`) and is therefore untrusted user input. A client controlling that field could break out of the OData string literal (e.g. by submitting `foo' or '1' eq '1`) and modify the filter, which lets the validation be bypassed by matching an arbitrary device whose deviceId happens to equal the supplied `aadDeviceId`. Fixed by escaping single quotes per the OData spec (a literal single quote is encoded as two single quotes) before embedding the value.

## Test plan

- [ ] Send a normal inventory POST with a plain hostname and confirm validation still succeeds end-to-end and data lands in Log Analytics.
- [ ] Send a hostname containing a single quote (e.g. `O'Brien-PC`) and confirm the filter still matches a legitimate device with that name (i.e. the escape is functional, not just defensive).
- [ ] Send a hostname containing an injection payload (e.g. `foo' or '1' eq '1`) for a device the caller does not own, and confirm validation fails as expected (no filter bypass).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)