### PR TITLE
Add ManagementImprovements: 10 housekeeping scripts for Intune admins

### DIFF
--- a/ManagementImprovements/Backup-IntuneConfiguration/Backup-IntuneConfiguration.ps1
+++ b/ManagementImprovements/Backup-IntuneConfiguration/Backup-IntuneConfiguration.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Export Intune configuration objects to JSON for backup / source control.
+.DESCRIPTION
+    Exports configuration profiles (classic + settings catalog), compliance
+    policies, platform scripts, proactive remediations, app protection policies,
+    Autopilot deployment profiles, assignment filters and mobileApps as JSON
+    files into a dated folder. Each object is written separately so the output
+    can be committed to git and diffed across runs.
+.PARAMETER OutputPath
+    Root output folder. A timestamped subfolder is created inside. Default: .\backup
+.PARAMETER IncludeAssignments
+    If set, also exports the assignments collection for each object.
+.EXAMPLE
+    .\Backup-IntuneConfiguration.ps1 -IncludeAssignments
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [string]$OutputPath = ".\backup",
+    [switch]$IncludeAssignments
+)
+
+$endpoints = @(
+    @{ Name = 'deviceConfigurations';                Uri = 'deviceManagement/deviceConfigurations' }
+    @{ Name = 'configurationPolicies';               Uri = 'deviceManagement/configurationPolicies' }
+    @{ Name = 'deviceCompliancePolicies';            Uri = 'deviceManagement/deviceCompliancePolicies' }
+    @{ Name = 'deviceManagementScripts';             Uri = 'deviceManagement/deviceManagementScripts' }
+    @{ Name = 'deviceShellScripts';                  Uri = 'deviceManagement/deviceShellScripts' }
+    @{ Name = 'deviceHealthScripts';                 Uri = 'deviceManagement/deviceHealthScripts' }
+    @{ Name = 'windowsAutopilotDeploymentProfiles';  Uri = 'deviceManagement/windowsAutopilotDeploymentProfiles' }
+    @{ Name = 'assignmentFilters';                   Uri = 'deviceManagement/assignmentFilters' }
+    @{ Name = 'mobileApps';                          Uri = 'deviceAppManagement/mobileApps' }
+    @{ Name = 'managedAppPolicies';                  Uri = 'deviceAppManagement/managedAppPolicies' }
+    @{ Name = 'mobileAppConfigurations';             Uri = 'deviceAppManagement/mobileAppConfigurations' }
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementConfiguration.Read.All",
+            "DeviceManagementApps.Read.All",
+            "DeviceManagementServiceConfig.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$RelativeUri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    $uri = "https://graph.microsoft.com/beta/$RelativeUri"
+    while ($uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+function Save-Object {
+    Param(
+        [Parameter(Mandatory)] [object]$Object,
+        [Parameter(Mandatory)] [string]$Folder
+    )
+    $name = if ($Object.displayName) { $Object.displayName } elseif ($Object.name) { $Object.name } else { $Object.id }
+    $safe = ($name -replace '[\\/:*?"<>|]', '_') + '_' + $Object.id + '.json'
+    $path = Join-Path $Folder $safe
+    ($Object | ConvertTo-Json -Depth 25) | Out-File -FilePath $path -Encoding UTF8
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    $stamp = (Get-Date).ToString('yyyyMMdd-HHmmss')
+    $root  = Join-Path -Path $OutputPath -ChildPath $stamp
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+    foreach ($e in $endpoints) {
+        Write-Host "Exporting $($e.Name)..." -ForegroundColor Cyan
+        $folder = Join-Path $root $e.Name
+        New-Item -ItemType Directory -Path $folder -Force | Out-Null
+
+        $items = Get-AllPages -RelativeUri $e.Uri
+        Write-Host "  $($items.Count) items"
+        foreach ($item in $items) {
+            if ($IncludeAssignments) {
+                try {
+                    $a = Invoke-MgGraphRequest -Method GET `
+                        -Uri "https://graph.microsoft.com/beta/$($e.Uri)/$($item.id)/assignments"
+                    $item | Add-Member -NotePropertyName '_assignments' -NotePropertyValue $a.value -Force
+                } catch {
+                    Write-Verbose "No assignments for $($item.id): $_"
+                }
+            }
+            Save-Object -Object $item -Folder $folder
+        }
+    }
+
+    Write-Host "Backup completed: $root" -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Backup-IntuneConfiguration failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Find-DuplicateDevices/Find-DuplicateDevices.ps1
+++ b/ManagementImprovements/Find-DuplicateDevices/Find-DuplicateDevices.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Find duplicate Intune-managed device records.
+.DESCRIPTION
+    Detects devices that share the same serial number (typical for re-enrolled or
+    re-imaged endpoints). For each duplicate group, keeps the most-recently
+    synced record and exports the older duplicates to CSV. Optionally removes
+    the older duplicates from Intune.
+.PARAMETER OutputPath
+    CSV output path. Default: .\duplicate-devices.csv
+.PARAMETER RemoveOld
+    When set, deletes the older duplicate records via Graph. Requires
+    DeviceManagementManagedDevices.PrivilegedOperations.All scope.
+.EXAMPLE
+    .\Find-DuplicateDevices.ps1
+.EXAMPLE
+    .\Find-DuplicateDevices.ps1 -RemoveOld
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+    Note   : Devices with empty / null serial numbers are excluded so VMs that
+             share the literal "0" or "SystemSerialNumber" do not match.
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+Param(
+    [string]$OutputPath = ".\duplicate-devices.csv",
+    [switch]$RemoveOld
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        $scope = if ($RemoveOld) {
+            "DeviceManagementManagedDevices.PrivilegedOperations.All"
+        } else {
+            "DeviceManagementManagedDevices.Read.All"
+        }
+        Connect-MgGraph -Scopes $scope -NoWelcome
+    }
+}
+
+function Get-AllManagedDevices {
+    $devices = [System.Collections.Generic.List[object]]::new()
+    $uri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$select=id,deviceName,userPrincipalName,serialNumber,model,manufacturer,operatingSystem,lastSyncDateTime,enrolledDateTime"
+    while ($uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $uri
+        foreach ($d in $page.value) { $devices.Add($d) }
+        $uri = $page.'@odata.nextLink'
+    }
+    return $devices
+}
+
+$invalidSerials = @('', '0', 'Default string', 'SystemSerialNumber', 'To be filled by O.E.M.', 'None')
+
+try {
+    Connect-MgGraphIfNeeded
+    $all = Get-AllManagedDevices
+    Write-Host "Retrieved $($all.Count) managed devices." -ForegroundColor Cyan
+
+    $usable = $all | Where-Object {
+        $_.serialNumber -and ($invalidSerials -notcontains $_.serialNumber.Trim())
+    }
+
+    $groups = $usable | Group-Object serialNumber | Where-Object { $_.Count -gt 1 }
+    Write-Host "Duplicate serial-number groups: $($groups.Count)" -ForegroundColor Yellow
+
+    $toRemove = [System.Collections.Generic.List[object]]::new()
+    foreach ($g in $groups) {
+        $sorted = $g.Group | Sort-Object { [datetime]$_.lastSyncDateTime } -Descending
+        $keep = $sorted | Select-Object -First 1
+        $duplicates = $sorted | Select-Object -Skip 1
+        foreach ($d in $duplicates) {
+            $toRemove.Add([pscustomobject]@{
+                serialNumber       = $g.Name
+                duplicateName      = $d.deviceName
+                duplicateId        = $d.id
+                duplicateLastSync  = $d.lastSyncDateTime
+                duplicateUpn       = $d.userPrincipalName
+                duplicateOs        = $d.operatingSystem
+                keepName           = $keep.deviceName
+                keepId             = $keep.id
+                keepLastSync       = $keep.lastSyncDateTime
+            })
+        }
+    }
+
+    $toRemove | Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Older duplicate records: $($toRemove.Count) -> $OutputPath" -ForegroundColor Green
+
+    if ($RemoveOld -and $toRemove.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess("$($toRemove.Count) duplicate device records", 'Delete')) {
+            foreach ($r in $toRemove) {
+                try {
+                    Invoke-MgGraphRequest -Method DELETE `
+                        -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($r.duplicateId)"
+                    Write-Host "Deleted: $($r.duplicateName)" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Failed to delete $($r.duplicateName): $_"
+                }
+            }
+        }
+    }
+    exit 0
+} catch {
+    Write-Error "Find-DuplicateDevices failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Find-EmptyAssignmentGroups/Find-EmptyAssignmentGroups.ps1
+++ b/ManagementImprovements/Find-EmptyAssignmentGroups/Find-EmptyAssignmentGroups.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Find Entra ID groups used in Intune assignments that have zero members.
+.DESCRIPTION
+    Empty assignment groups are a common source of "ghost" assignments that look
+    targeted but never reach a device. This script enumerates every group ID
+    referenced by an Intune assignment (configuration profiles, compliance
+    policies, scripts, apps, app config, autopilot profiles, filters) and
+    reports those whose membership count is zero.
+.PARAMETER OutputPath
+    CSV output path. Default: .\empty-assignment-groups.csv
+.EXAMPLE
+    .\Find-EmptyAssignmentGroups.ps1
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [string]$OutputPath = ".\empty-assignment-groups.csv"
+)
+
+$assignmentSources = @(
+    'deviceManagement/deviceConfigurations',
+    'deviceManagement/configurationPolicies',
+    'deviceManagement/deviceCompliancePolicies',
+    'deviceManagement/deviceManagementScripts',
+    'deviceManagement/deviceShellScripts',
+    'deviceManagement/deviceHealthScripts',
+    'deviceManagement/windowsAutopilotDeploymentProfiles',
+    'deviceAppManagement/mobileApps',
+    'deviceAppManagement/managedAppPolicies',
+    'deviceAppManagement/mobileAppConfigurations'
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementConfiguration.Read.All",
+            "DeviceManagementApps.Read.All",
+            "Group.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    $groupIds = [System.Collections.Generic.HashSet[string]]::new()
+    $usage    = @{}
+
+    foreach ($source in $assignmentSources) {
+        Write-Host "Collecting assignments from $source ..." -ForegroundColor Cyan
+        try {
+            $items = Get-AllPages -Uri "https://graph.microsoft.com/beta/$source?`$expand=assignments"
+        } catch {
+            Write-Warning "Skipping $source -> $_"
+            continue
+        }
+        foreach ($item in $items) {
+            foreach ($a in @($item.assignments)) {
+                $targetType = $a.target.'@odata.type'
+                if ($targetType -eq '#microsoft.graph.groupAssignmentTarget' -or
+                    $targetType -eq '#microsoft.graph.exclusionGroupAssignmentTarget') {
+                    $gid = $a.target.groupId
+                    [void]$groupIds.Add($gid)
+                    if (-not $usage.ContainsKey($gid)) { $usage[$gid] = [System.Collections.Generic.List[string]]::new() }
+                    $name = if ($item.displayName) { $item.displayName } else { $item.name }
+                    $usage[$gid].Add("$source/$name")
+                }
+            }
+        }
+    }
+
+    Write-Host "Unique groups referenced: $($groupIds.Count)" -ForegroundColor Cyan
+    $empty = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($gid in $groupIds) {
+        try {
+            $count = Invoke-MgGraphRequest -Method GET `
+                -Uri "https://graph.microsoft.com/beta/groups/$gid/members/`$count" `
+                -Headers @{ ConsistencyLevel = 'eventual' }
+            if ([int]$count -eq 0) {
+                $g = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/groups/$gid"
+                $empty.Add([pscustomobject]@{
+                    groupId    = $gid
+                    groupName  = $g.displayName
+                    usageCount = $usage[$gid].Count
+                    usedBy     = ($usage[$gid] -join '; ')
+                })
+            }
+        } catch {
+            Write-Verbose "Group $gid lookup failed: $_"
+        }
+    }
+
+    Write-Host "Empty assignment groups: $($empty.Count)" -ForegroundColor Yellow
+    $empty | Sort-Object usageCount -Descending |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Find-EmptyAssignmentGroups failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Find-StaleDevices/Find-StaleDevices.ps1
+++ b/ManagementImprovements/Find-StaleDevices/Find-StaleDevices.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Find Intune-managed devices that haven't synced for a given number of days.
+.DESCRIPTION
+    Queries Microsoft Graph for all managed devices, filters by lastSyncDateTime
+    older than the supplied threshold and exports the result to CSV. Optionally
+    triggers a remote-wipe of stale, retired-eligible devices when -Action Retire
+    is specified (requires confirmation).
+.PARAMETER DaysStale
+    Number of days since lastSyncDateTime that marks a device as stale. Default: 90.
+.PARAMETER OutputPath
+    CSV output path. Default: .\stale-devices.csv
+.PARAMETER Action
+    Report (default) or Retire. Retire performs Invoke-MgRetireManagedDevice on
+    each stale device after a confirmation prompt.
+.EXAMPLE
+    .\Find-StaleDevices.ps1 -DaysStale 60
+.EXAMPLE
+    .\Find-StaleDevices.ps1 -DaysStale 180 -Action Retire
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+Param(
+    [ValidateRange(1, 3650)]
+    [int]$DaysStale = 90,
+
+    [string]$OutputPath = ".\stale-devices.csv",
+
+    [ValidateSet('Report', 'Retire')]
+    [string]$Action = 'Report'
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementManagedDevices.ReadWrite.All" -NoWelcome
+    }
+}
+
+function Get-AllManagedDevices {
+    $devices = [System.Collections.Generic.List[object]]::new()
+    $uri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$select=id,deviceName,userPrincipalName,operatingSystem,osVersion,complianceState,managementAgent,lastSyncDateTime,serialNumber,model,manufacturer"
+    while ($uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $uri
+        foreach ($d in $page.value) { $devices.Add($d) }
+        $uri = $page.'@odata.nextLink'
+    }
+    return $devices
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    $cutoff = (Get-Date).ToUniversalTime().AddDays(-$DaysStale)
+    Write-Host "Cutoff date (UTC): $cutoff" -ForegroundColor Cyan
+
+    $all = Get-AllManagedDevices
+    Write-Host "Retrieved $($all.Count) managed devices." -ForegroundColor Cyan
+
+    $stale = $all | Where-Object {
+        $_.lastSyncDateTime -and ([datetime]$_.lastSyncDateTime) -lt $cutoff
+    } | Sort-Object lastSyncDateTime
+
+    Write-Host "Stale devices: $($stale.Count)" -ForegroundColor Yellow
+
+    $stale | Select-Object deviceName, userPrincipalName, operatingSystem, osVersion,
+        complianceState, managementAgent, lastSyncDateTime, serialNumber, model, id |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+
+    if ($Action -eq 'Retire' -and $stale.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess("$($stale.Count) stale devices", 'Retire')) {
+            foreach ($d in $stale) {
+                try {
+                    Invoke-MgGraphRequest -Method POST `
+                        -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($d.id)/retire"
+                    Write-Host "Retired: $($d.deviceName)" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Failed to retire $($d.deviceName): $_"
+                }
+            }
+        }
+    }
+
+    exit 0
+} catch {
+    Write-Error "Find-StaleDevices failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Find-UnassignedPlatformScripts/Find-UnassignedPlatformScripts.ps1
+++ b/ManagementImprovements/Find-UnassignedPlatformScripts/Find-UnassignedPlatformScripts.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Find platform / shell / proactive-remediation scripts without assignments.
+.DESCRIPTION
+    Scans deviceManagementScripts (Windows), deviceShellScripts (macOS) and
+    deviceHealthScripts (Proactive Remediations) and reports any items with no
+    assignments. Helpful for catching "draft" scripts that were never rolled
+    out.
+.PARAMETER OutputPath
+    CSV output path. Default: .\unassigned-scripts.csv
+.EXAMPLE
+    .\Find-UnassignedPlatformScripts.ps1
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [string]$OutputPath = ".\unassigned-scripts.csv"
+)
+
+$endpoints = @(
+    @{ Type = 'Windows-PowerShell'; Uri = 'deviceManagement/deviceManagementScripts' }
+    @{ Type = 'macOS-Shell';        Uri = 'deviceManagement/deviceShellScripts' }
+    @{ Type = 'Proactive-Remediation'; Uri = 'deviceManagement/deviceHealthScripts' }
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.Read.All" -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    $unassigned = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($e in $endpoints) {
+        Write-Host "Scanning $($e.Type) ($($e.Uri))..." -ForegroundColor Cyan
+        $items = Get-AllPages -Uri "https://graph.microsoft.com/beta/$($e.Uri)?`$expand=assignments"
+        Write-Host "  $($items.Count) items"
+        foreach ($i in $items) {
+            if (-not $i.assignments -or $i.assignments.Count -eq 0) {
+                $unassigned.Add([pscustomobject]@{
+                    type                 = $e.Type
+                    id                   = $i.id
+                    displayName          = $i.displayName
+                    publisher            = $i.publisher
+                    createdDateTime      = $i.createdDateTime
+                    lastModifiedDateTime = $i.lastModifiedDateTime
+                })
+            }
+        }
+    }
+
+    Write-Host "Unassigned scripts: $($unassigned.Count)" -ForegroundColor Yellow
+    $unassigned | Sort-Object type, lastModifiedDateTime |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Find-UnassignedPlatformScripts failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Find-UnusedFilters/Find-UnusedFilters.ps1
+++ b/ManagementImprovements/Find-UnusedFilters/Find-UnusedFilters.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Find Intune assignment filters that are not referenced by any assignment.
+.DESCRIPTION
+    Lists all assignment filters in the tenant and cross-checks them against
+    every assignment across configuration profiles, compliance policies,
+    scripts, autopilot profiles and mobile apps. Filters that appear in zero
+    assignments are reported.
+.PARAMETER OutputPath
+    CSV output path. Default: .\unused-filters.csv
+.PARAMETER Delete
+    If set, deletes the unused filters after a confirmation prompt.
+.EXAMPLE
+    .\Find-UnusedFilters.ps1
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+Param(
+    [string]$OutputPath = ".\unused-filters.csv",
+    [switch]$Delete
+)
+
+$assignmentSources = @(
+    'deviceManagement/deviceConfigurations',
+    'deviceManagement/configurationPolicies',
+    'deviceManagement/deviceCompliancePolicies',
+    'deviceManagement/deviceManagementScripts',
+    'deviceManagement/deviceShellScripts',
+    'deviceManagement/deviceHealthScripts',
+    'deviceManagement/windowsAutopilotDeploymentProfiles',
+    'deviceAppManagement/mobileApps',
+    'deviceAppManagement/mobileAppConfigurations'
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementConfiguration.ReadWrite.All",
+            "DeviceManagementApps.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+
+    $filters = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceManagement/assignmentFilters"
+    Write-Host "Filters in tenant: $($filters.Count)" -ForegroundColor Cyan
+
+    $usedIds = [System.Collections.Generic.HashSet[string]]::new()
+
+    foreach ($source in $assignmentSources) {
+        Write-Host "Scanning $source ..." -ForegroundColor Cyan
+        try {
+            $items = Get-AllPages -Uri "https://graph.microsoft.com/beta/$source?`$expand=assignments"
+        } catch {
+            Write-Warning "Skipping $source -> $_"
+            continue
+        }
+        foreach ($item in $items) {
+            foreach ($a in @($item.assignments)) {
+                if ($a.target.deviceAndAppManagementAssignmentFilterId) {
+                    [void]$usedIds.Add($a.target.deviceAndAppManagementAssignmentFilterId)
+                }
+            }
+        }
+    }
+
+    $unused = $filters | Where-Object { -not $usedIds.Contains($_.id) }
+    Write-Host "Unused filters: $($unused.Count)" -ForegroundColor Yellow
+
+    $unused | Select-Object id, displayName, platform, rule, createdDateTime, lastModifiedDateTime |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+
+    if ($Delete -and $unused.Count -gt 0) {
+        if ($PSCmdlet.ShouldProcess("$($unused.Count) unused filters", 'Delete')) {
+            foreach ($f in $unused) {
+                try {
+                    Invoke-MgGraphRequest -Method DELETE `
+                        -Uri "https://graph.microsoft.com/beta/deviceManagement/assignmentFilters/$($f.id)"
+                    Write-Host "Deleted: $($f.displayName)" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Failed to delete $($f.displayName): $_"
+                }
+            }
+        }
+    }
+    exit 0
+} catch {
+    Write-Error "Find-UnusedFilters failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Get-AppInstallSuccessRate/Get-AppInstallSuccessRate.ps1
+++ b/ManagementImprovements/Get-AppInstallSuccessRate/Get-AppInstallSuccessRate.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Compute the install success rate of every assigned Intune app.
+.DESCRIPTION
+    For each assigned mobileApp, fetches the installSummary and computes the
+    success / failure / pending counts per scope (device + user). Apps below
+    the configurable threshold are highlighted so admins can investigate the
+    underlying packaging or detection-rule problems.
+.PARAMETER WarnBelow
+    Success-rate threshold (0-100) below which the app is highlighted in the
+    console output. Default: 80.
+.PARAMETER OutputPath
+    CSV output path. Default: .\app-install-success.csv
+.PARAMETER IncludeUnassigned
+    Also include apps without assignments. Default: only assigned apps.
+.EXAMPLE
+    .\Get-AppInstallSuccessRate.ps1
+.EXAMPLE
+    .\Get-AppInstallSuccessRate.ps1 -WarnBelow 95 -OutputPath C:\temp\apps.csv
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [ValidateRange(0, 100)]
+    [int]$WarnBelow = 80,
+    [string]$OutputPath = ".\app-install-success.csv",
+    [switch]$IncludeUnassigned
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes "DeviceManagementApps.Read.All" -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    Write-Host "Loading mobileApps..." -ForegroundColor Cyan
+    $apps = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps?`$expand=assignments&`$select=id,displayName,publisher,assignments,'@odata.type'"
+    Write-Host "Total apps: $($apps.Count)" -ForegroundColor Cyan
+
+    if (-not $IncludeUnassigned) {
+        $apps = $apps | Where-Object { $_.assignments.Count -gt 0 }
+    }
+
+    $rows = foreach ($app in $apps) {
+        try {
+            $s = Invoke-MgGraphRequest -Method GET `
+                -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/installSummary"
+        } catch {
+            Write-Verbose "InstallSummary not available for $($app.displayName)"
+            continue
+        }
+        $devTotal  = [int]$s.installedDeviceCount + [int]$s.failedDeviceCount + [int]$s.notInstalledDeviceCount + [int]$s.notApplicableDeviceCount + [int]$s.pendingInstallDeviceCount
+        $userTotal = [int]$s.installedUserCount + [int]$s.failedUserCount + [int]$s.notInstalledUserCount + [int]$s.notApplicableUserCount + [int]$s.pendingInstallUserCount
+
+        $devSuccess  = if ($devTotal)  { [math]::Round((([int]$s.installedDeviceCount) / $devTotal)  * 100, 2) } else { $null }
+        $userSuccess = if ($userTotal) { [math]::Round((([int]$s.installedUserCount)   / $userTotal) * 100, 2) } else { $null }
+
+        [pscustomobject]@{
+            appId                    = $app.id
+            displayName              = $app.displayName
+            publisher                = $app.publisher
+            type                     = $app.'@odata.type'
+            installedDeviceCount     = $s.installedDeviceCount
+            failedDeviceCount        = $s.failedDeviceCount
+            pendingInstallDeviceCount= $s.pendingInstallDeviceCount
+            notInstalledDeviceCount  = $s.notInstalledDeviceCount
+            notApplicableDeviceCount = $s.notApplicableDeviceCount
+            installedUserCount       = $s.installedUserCount
+            failedUserCount          = $s.failedUserCount
+            deviceSuccessPercent     = $devSuccess
+            userSuccessPercent       = $userSuccess
+        }
+    }
+
+    $rows | Sort-Object deviceSuccessPercent |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+
+    $warn = $rows | Where-Object { $_.deviceSuccessPercent -ne $null -and $_.deviceSuccessPercent -lt $WarnBelow }
+    if ($warn) {
+        Write-Host "Apps below ${WarnBelow}% device install success:" -ForegroundColor Yellow
+        $warn | Format-Table displayName, deviceSuccessPercent, failedDeviceCount, installedDeviceCount -AutoSize
+    }
+
+    exit 0
+} catch {
+    Write-Error "Get-AppInstallSuccessRate failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Get-BitLockerEscrowReport/Get-BitLockerEscrowReport.ps1
+++ b/ManagementImprovements/Get-BitLockerEscrowReport/Get-BitLockerEscrowReport.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Report Windows devices that have no BitLocker recovery key escrowed to Entra ID.
+.DESCRIPTION
+    Joins the list of managed Windows devices with the BitLocker recoveryKeys
+    resource in Microsoft Graph. Devices that have at least one key escrowed
+    are reported as compliant; the rest are flagged in a CSV report so admins
+    can chase down endpoints that are encrypted but lack a stored recovery key.
+.PARAMETER OutputPath
+    CSV output path. Default: .\bitlocker-escrow-report.csv
+.PARAMETER IncludeCompliantDevices
+    Also include compliant devices in the CSV (default: only non-compliant).
+.EXAMPLE
+    .\Get-BitLockerEscrowReport.ps1
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+    Note   : Requires the BitLockerKey.ReadBasic.All scope.
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [string]$OutputPath = ".\bitlocker-escrow-report.csv",
+    [switch]$IncludeCompliantDevices
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementManagedDevices.Read.All",
+            "BitLockerKey.ReadBasic.All",
+            "Device.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+
+    Write-Host "Loading Windows managed devices..." -ForegroundColor Cyan
+    $devices = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$filter=operatingSystem eq 'Windows'&`$select=id,deviceName,userPrincipalName,azureADDeviceId,model,osVersion,lastSyncDateTime,joinType"
+    Write-Host "Windows devices: $($devices.Count)" -ForegroundColor Cyan
+
+    Write-Host "Loading BitLocker recovery keys..." -ForegroundColor Cyan
+    $keys = Get-AllPages -Uri "https://graph.microsoft.com/beta/informationProtection/bitlocker/recoveryKeys?`$select=id,deviceId,createdDateTime,volumeType"
+    Write-Host "Recovery keys: $($keys.Count)" -ForegroundColor Cyan
+
+    $byDevice = $keys | Group-Object deviceId -AsHashTable -AsString
+
+    $report = foreach ($d in $devices) {
+        $hasKey  = $byDevice -and $d.azureADDeviceId -and $byDevice.ContainsKey($d.azureADDeviceId)
+        $keyList = if ($hasKey) { $byDevice[$d.azureADDeviceId] } else { @() }
+        [pscustomobject]@{
+            deviceName            = $d.deviceName
+            userPrincipalName     = $d.userPrincipalName
+            azureADDeviceId       = $d.azureADDeviceId
+            joinType              = $d.joinType
+            osVersion             = $d.osVersion
+            lastSyncDateTime      = $d.lastSyncDateTime
+            hasRecoveryKey        = [bool]$hasKey
+            recoveryKeyCount      = $keyList.Count
+            volumesProtected      = (($keyList | Select-Object -ExpandProperty volumeType -Unique) -join ',')
+            mostRecentEscrow      = ($keyList | Sort-Object createdDateTime -Descending | Select-Object -First 1 -ExpandProperty createdDateTime)
+        }
+    }
+
+    $output = if ($IncludeCompliantDevices) { $report } else { $report | Where-Object { -not $_.hasRecoveryKey } }
+
+    $missing = ($report | Where-Object { -not $_.hasRecoveryKey }).Count
+    Write-Host "Devices without escrowed recovery key: $missing" -ForegroundColor Yellow
+
+    $output | Sort-Object hasRecoveryKey, deviceName |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Get-BitLockerEscrowReport failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/Get-PolicyConflictReport/Get-PolicyConflictReport.ps1
+++ b/ManagementImprovements/Get-PolicyConflictReport/Get-PolicyConflictReport.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Report all device-configuration policies in a conflict state.
+.DESCRIPTION
+    Pulls the per-device, per-policy reporting status via Graph and surfaces
+    every entry whose state is "conflict" or "error". Optionally narrows the
+    report to a single device.
+.PARAMETER DeviceName
+    Limit the report to a single managed device by display name (optional).
+.PARAMETER OutputPath
+    CSV output path. Default: .\policy-conflicts.csv
+.EXAMPLE
+    .\Get-PolicyConflictReport.ps1
+.EXAMPLE
+    .\Get-PolicyConflictReport.ps1 -DeviceName "DESKTOP-AB1234"
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [string]$DeviceName,
+    [string]$OutputPath = ".\policy-conflicts.csv"
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementManagedDevices.Read.All",
+            "DeviceManagementConfiguration.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+
+    $filter = if ($DeviceName) {
+        "?`$filter=deviceName eq '$($DeviceName.Replace("'","''"))'&`$select=id,deviceName,userPrincipalName"
+    } else {
+        "?`$select=id,deviceName,userPrincipalName"
+    }
+    $devices = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices$filter"
+    Write-Host "Devices in scope: $($devices.Count)" -ForegroundColor Cyan
+
+    $conflicts = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($d in $devices) {
+        try {
+            $states = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($d.id)/deviceConfigurationStates"
+        } catch {
+            Write-Verbose "deviceConfigurationStates failed for $($d.deviceName): $_"
+            continue
+        }
+        foreach ($s in $states) {
+            if ($s.state -in @('conflict', 'error')) {
+                $conflicts.Add([pscustomobject]@{
+                    deviceName        = $d.deviceName
+                    userPrincipalName = $d.userPrincipalName
+                    policyName        = $s.displayName
+                    state             = $s.state
+                    settingCount      = $s.settingCount
+                    platformType      = $s.platformType
+                    version           = $s.version
+                })
+            }
+        }
+    }
+
+    Write-Host "Conflict / error entries: $($conflicts.Count)" -ForegroundColor Yellow
+    $conflicts | Sort-Object deviceName, policyName |
+        Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+    Write-Host "Report written to $OutputPath" -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Get-PolicyConflictReport failed: $_"
+    exit 1
+}

--- a/ManagementImprovements/README.md
+++ b/ManagementImprovements/README.md
@@ -1,0 +1,60 @@
+# Management Improvements
+
+Solutions and reports that surface common Intune housekeeping problems and make
+day-to-day tenant administration easier. Every script connects via
+`Connect-MgGraph`, paginates the response, exports a CSV (where applicable)
+and exits with `0` (success) or `1` (error).
+
+| Script | Purpose | Required Graph Scopes |
+|---|---|---|
+| [`Find-StaleDevices/`](Find-StaleDevices/Find-StaleDevices.ps1) | List managed devices that haven't synced for *N* days; optionally retire them. | `DeviceManagementManagedDevices.ReadWrite.All` |
+| [`Find-DuplicateDevices/`](Find-DuplicateDevices/Find-DuplicateDevices.ps1) | Find duplicate device records by serial number, keep the most-recent sync, optionally delete the older record. | `DeviceManagementManagedDevices.Read.All` (+`PrivilegedOperations.All` when `-RemoveOld`) |
+| [`Backup-IntuneConfiguration/`](Backup-IntuneConfiguration/Backup-IntuneConfiguration.ps1) | Export configuration profiles, compliance policies, scripts, apps, app config, Autopilot profiles and filters into a timestamped JSON tree — ready to commit to git. | `DeviceManagementConfiguration.Read.All`, `DeviceManagementApps.Read.All`, `DeviceManagementServiceConfig.Read.All` |
+| [`Find-EmptyAssignmentGroups/`](Find-EmptyAssignmentGroups/Find-EmptyAssignmentGroups.ps1) | Detect Entra ID groups used in Intune assignments that have zero members ("ghost" assignments). | `DeviceManagementConfiguration.Read.All`, `DeviceManagementApps.Read.All`, `Group.Read.All` |
+| [`Find-UnusedFilters/`](Find-UnusedFilters/Find-UnusedFilters.ps1) | Detect assignment filters that are not referenced by any assignment; optionally delete them. | `DeviceManagementConfiguration.ReadWrite.All`, `DeviceManagementApps.Read.All` |
+| [`Get-BitLockerEscrowReport/`](Get-BitLockerEscrowReport/Get-BitLockerEscrowReport.ps1) | Cross-check managed Windows devices against escrowed BitLocker recovery keys; report devices missing a key. | `DeviceManagementManagedDevices.Read.All`, `BitLockerKey.ReadBasic.All`, `Device.Read.All` |
+| [`Get-AppInstallSuccessRate/`](Get-AppInstallSuccessRate/Get-AppInstallSuccessRate.ps1) | Compute per-app install success rate from `installSummary`; highlight apps below a threshold. | `DeviceManagementApps.Read.All` |
+| [`Find-UnassignedPlatformScripts/`](Find-UnassignedPlatformScripts/Find-UnassignedPlatformScripts.ps1) | Find Windows PowerShell scripts, macOS shell scripts and Proactive Remediations without assignments. | `DeviceManagementConfiguration.Read.All` |
+| [`Test-IntuneHealth/`](Test-IntuneHealth/Test-IntuneHealth.ps1) | Quick tenant health summary: resource counts, compliance state, stale devices, APNS certificate expiry. | `DeviceManagementManagedDevices.Read.All`, `DeviceManagementConfiguration.Read.All`, `DeviceManagementApps.Read.All`, `DeviceManagementServiceConfig.Read.All` |
+| [`Get-PolicyConflictReport/`](Get-PolicyConflictReport/Get-PolicyConflictReport.ps1) | List device-configuration policies in `conflict` or `error` state, tenant-wide or for a single device. | `DeviceManagementManagedDevices.Read.All`, `DeviceManagementConfiguration.Read.All` |
+
+## Common patterns
+
+All scripts share the same idioms:
+
+```powershell
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes "..." -NoWelcome
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+```
+
+- Pagination is always handled via `@odata.nextLink`.
+- Destructive actions (retire devices, delete filters, delete duplicate
+  records) are gated behind `SupportsShouldProcess` with `ConfirmImpact =
+  'High'` so they prompt by default.
+- All outputs are written as UTF-8 CSV for easy ingestion into Power BI, Excel,
+  or follow-up automation.
+
+## Running
+
+```powershell
+# Examples
+.\Test-IntuneHealth\Test-IntuneHealth.ps1
+.\Find-StaleDevices\Find-StaleDevices.ps1 -DaysStale 120
+.\Backup-IntuneConfiguration\Backup-IntuneConfiguration.ps1 -IncludeAssignments
+.\Find-EmptyAssignmentGroups\Find-EmptyAssignmentGroups.ps1
+.\Get-BitLockerEscrowReport\Get-BitLockerEscrowReport.ps1
+```

--- a/ManagementImprovements/Test-IntuneHealth/Test-IntuneHealth.ps1
+++ b/ManagementImprovements/Test-IntuneHealth/Test-IntuneHealth.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+    Run a quick health check of the Intune tenant.
+.DESCRIPTION
+    Verifies Graph connectivity, gathers tenant context, counts core resources
+    (devices, configurations, compliance policies, apps, autopilot devices)
+    and surfaces common problem indicators: non-compliant devices, devices not
+    synced in 30 days, failing apps, empty assignment groups, expiring Apple
+    push certificate.
+.PARAMETER StaleThresholdDays
+    Days since lastSyncDateTime to consider a device "stale". Default: 30.
+.EXAMPLE
+    .\Test-IntuneHealth.ps1
+.NOTES
+    Author : Jannik Reinhard
+    Version: 1.0
+#>
+
+#Requires -Modules Microsoft.Graph.Authentication
+
+[CmdletBinding()]
+Param(
+    [ValidateRange(1, 365)]
+    [int]$StaleThresholdDays = 30
+)
+
+function Connect-MgGraphIfNeeded {
+    if (-not (Get-MgContext)) {
+        Connect-MgGraph -Scopes @(
+            "DeviceManagementManagedDevices.Read.All",
+            "DeviceManagementConfiguration.Read.All",
+            "DeviceManagementApps.Read.All",
+            "DeviceManagementServiceConfig.Read.All"
+        ) -NoWelcome
+    }
+}
+
+function Get-Count {
+    Param([Parameter(Mandatory)][string]$Uri)
+    try {
+        $r = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/$Uri/`$count" `
+            -Headers @{ ConsistencyLevel = 'eventual' }
+        return [int]$r
+    } catch {
+        # Some endpoints (deviceConfigurations) don't support $count; fall back to enumerating.
+        $total = 0
+        $u = "https://graph.microsoft.com/beta/$Uri"
+        while ($u) {
+            $p = Invoke-MgGraphRequest -Method GET -Uri $u
+            $total += $p.value.Count
+            $u = $p.'@odata.nextLink'
+        }
+        return $total
+    }
+}
+
+function Get-AllPages {
+    Param([Parameter(Mandatory)][string]$Uri)
+    $items = [System.Collections.Generic.List[object]]::new()
+    while ($Uri) {
+        $page = Invoke-MgGraphRequest -Method GET -Uri $Uri
+        foreach ($v in $page.value) { $items.Add($v) }
+        $Uri = $page.'@odata.nextLink'
+    }
+    return $items
+}
+
+try {
+    Connect-MgGraphIfNeeded
+    $ctx = Get-MgContext
+    Write-Host ""
+    Write-Host "=== Tenant context ===" -ForegroundColor Cyan
+    Write-Host "  Tenant : $($ctx.TenantId)"
+    Write-Host "  Account: $($ctx.Account)"
+    Write-Host "  Scopes : $($ctx.Scopes -join ', ')"
+
+    Write-Host ""
+    Write-Host "=== Resource counts ===" -ForegroundColor Cyan
+    $deviceCount = Get-Count -Uri "deviceManagement/managedDevices"
+    Write-Host "  Managed devices             : $deviceCount"
+    Write-Host "  Device configurations       : $(Get-Count -Uri 'deviceManagement/deviceConfigurations')"
+    Write-Host "  Settings-catalog policies   : $(Get-Count -Uri 'deviceManagement/configurationPolicies')"
+    Write-Host "  Compliance policies         : $(Get-Count -Uri 'deviceManagement/deviceCompliancePolicies')"
+    Write-Host "  Mobile apps                 : $(Get-Count -Uri 'deviceAppManagement/mobileApps')"
+    Write-Host "  Autopilot devices           : $(Get-Count -Uri 'deviceManagement/windowsAutopilotDeviceIdentities')"
+    Write-Host "  Assignment filters          : $(Get-Count -Uri 'deviceManagement/assignmentFilters')"
+    Write-Host "  Proactive remediations      : $(Get-Count -Uri 'deviceManagement/deviceHealthScripts')"
+
+    Write-Host ""
+    Write-Host "=== Compliance ===" -ForegroundColor Cyan
+    $summary = Invoke-MgGraphRequest -Method GET `
+        -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicyDeviceStateSummary"
+    Write-Host "  Compliant      : $($summary.compliantDeviceCount)"
+    Write-Host "  Non-compliant  : $($summary.nonCompliantDeviceCount)" -ForegroundColor Yellow
+    Write-Host "  In grace period: $($summary.inGracePeriodCount)"
+    Write-Host "  Error          : $($summary.errorDeviceCount)" -ForegroundColor Yellow
+    Write-Host "  Not applicable : $($summary.notApplicableDeviceCount)"
+
+    Write-Host ""
+    Write-Host "=== Stale devices (>$StaleThresholdDays days) ===" -ForegroundColor Cyan
+    $cutoff = (Get-Date).ToUniversalTime().AddDays(-$StaleThresholdDays).ToString("o")
+    $stale = Get-AllPages -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$filter=lastSyncDateTime lt $cutoff&`$select=id,deviceName,lastSyncDateTime"
+    Write-Host "  Stale device count: $($stale.Count)" -ForegroundColor $(if ($stale.Count -gt 0) { 'Yellow' } else { 'Green' })
+
+    Write-Host ""
+    Write-Host "=== Apple MDM push certificate ===" -ForegroundColor Cyan
+    try {
+        $apns = Invoke-MgGraphRequest -Method GET `
+            -Uri "https://graph.microsoft.com/beta/deviceManagement/applePushNotificationCertificate"
+        $expiry = [datetime]$apns.expirationDateTime
+        $days   = ($expiry - (Get-Date)).Days
+        $color  = if ($days -lt 30) { 'Red' } elseif ($days -lt 60) { 'Yellow' } else { 'Green' }
+        Write-Host "  Apple ID : $($apns.appleIdentifier)"
+        Write-Host "  Expires  : $expiry ($days days remaining)" -ForegroundColor $color
+    } catch {
+        Write-Host "  (no APNS configured or insufficient permissions)" -ForegroundColor DarkGray
+    }
+
+    Write-Host ""
+    Write-Host "Health check complete." -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Error "Test-IntuneHealth failed: $_"
+    exit 1
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This repository contains **40+ ready-to-use scripts** for Intune administrators 
 | `Hide-TaskViewWidgetsAndSearch/` | Remediation | Hide Task View, Widgets, and Search from taskbar |
 | `Ime-LogSummarizer/` | Diagnostics | AI-powered IME log analysis (local & remote, Python) |
 | `Make-Speedtest/` | Diagnostics | Download speed test with Log Analytics upload |
+| [`ManagementImprovements/`](ManagementImprovements/README.md) | Tenant Mgmt | 10 housekeeping scripts: stale/duplicate devices, config backup, empty groups, unused filters, BitLocker escrow, app success rate, unassigned scripts, tenant health, policy conflicts |
 | `Move-Windows11Taskbar/` | Remediation | Set Windows 11 taskbar alignment to left |
 | `Remove-ApplicabilityRule/` | Device Config | Strip OS applicability rules from all config profiles |
 | `Remove-PrimaryUserFromIntuneDevices/` | Device Mgmt | Remove primary user from managed devices |


### PR DESCRIPTION
## Summary

Adds a new top-level `ManagementImprovements/` folder with **10 ready-to-run scripts** that solve common Intune housekeeping pain points. Every script follows the existing repo conventions:

- comment-based help (`.SYNOPSIS` / `.DESCRIPTION` / `.NOTES` with `Author: Jannik Reinhard`)
- `Connect-MgGraphIfNeeded` helper
- paginated Graph calls via `@odata.nextLink`
- CSV export (UTF-8) and exit codes (`0` success / `1` error)
- destructive variants gated behind `SupportsShouldProcess` with `ConfirmImpact = 'High'`

## Scripts added

| Script | Purpose |
|---|---|
| `Find-StaleDevices/` | Report / retire devices stale > N days |
| `Find-DuplicateDevices/` | Report / delete duplicate device records (by serial number) |
| `Backup-IntuneConfiguration/` | Export configurations, compliance policies, scripts, apps, app config, Autopilot profiles & filters as JSON tree |
| `Find-EmptyAssignmentGroups/` | Detect Entra ID groups with zero members used in Intune assignments |
| `Find-UnusedFilters/` | Find / delete assignment filters not referenced by any assignment |
| `Get-BitLockerEscrowReport/` | Flag managed Windows devices missing a BitLocker recovery key escrow |
| `Get-AppInstallSuccessRate/` | Per-app install success % with low-rate threshold highlights |
| `Find-UnassignedPlatformScripts/` | PowerShell / shell / Proactive-Remediation scripts without assignments |
| `Test-IntuneHealth/` | Tenant overview: counts, compliance state, stale devices, APNS certificate expiry |
| `Get-PolicyConflictReport/` | Device-config policies in `conflict` / `error` state, tenant-wide or per device |

Also updates the root `README.md` to link the new folder.

## Verification

```
$ pwsh -c '[System.Management.Automation.Language.Parser]::ParseFile(...)' for all 10 .ps1
OK  : Find-UnusedFilters.ps1
OK  : Find-EmptyAssignmentGroups.ps1
OK  : Get-PolicyConflictReport.ps1
OK  : Backup-IntuneConfiguration.ps1
OK  : Test-IntuneHealth.ps1
OK  : Find-DuplicateDevices.ps1
OK  : Find-UnassignedPlatformScripts.ps1
OK  : Get-BitLockerEscrowReport.ps1
OK  : Find-StaleDevices.ps1
OK  : Get-AppInstallSuccessRate.ps1
All scripts parsed successfully.
```

## Test plan

- [ ] Spot-run `Test-IntuneHealth.ps1` against your tenant to confirm Graph scopes are accepted
- [ ] Run `Find-EmptyAssignmentGroups.ps1` and validate group lookups against Entra portal
- [ ] Run `Get-BitLockerEscrowReport.ps1` and cross-check 1-2 devices in the Intune portal
- [ ] Run `Backup-IntuneConfiguration.ps1 -IncludeAssignments` and inspect the JSON tree
- [ ] Verify destructive variants (`-Action Retire`, `-RemoveOld`, `-Delete`) prompt for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)